### PR TITLE
Fix types config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radix-ui/colors",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "contributors": [
     "Colm Tuite <colm@modulz.app>",
     "Vlad Moroz <vlad@modulz.app>"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "main": "index.js",
   "module": "index.mjs",
-  "typings": "types/index.d.ts",
+  "types": "types/index.d.ts",
   "scripts": {
     "build": "yarn clean && yarn && rollup -c && yarn build-css-modules",
     "build-css-modules": "node ./scripts/build-css-modules.js",


### PR DESCRIPTION
`package.json` field for type file is `types` not `typings`.
This make the type file undetected by type checkers.

Reference:
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html